### PR TITLE
Add basic Boomi MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,35 @@
-# boomi-mcp-server
-An MCP server for interaction with the Boomi API.
+# Boomi MCP Server
+
+This repository provides a simple [Model Context Protocol](https://modelcontextprotocol.io) (MCP) server
+for interacting with the Boomi API. The server exposes a few Boomi SDK
+operations as MCP tools using [FastMCP](https://pypi.org/project/fastmcp/).
+
+## Requirements
+
+- Python 3.10+
+- Access credentials for the Boomi API
+
+Install dependencies with `pip` or any PEP 517 build frontend:
+
+```bash
+pip install -e .
+```
+
+## Usage
+
+Set your Boomi credentials as environment variables:
+
+```bash
+export BOOMI_ACCOUNT=...
+export BOOMI_USER=...
+export BOOMI_SECRET=...
+```
+
+Then start the server:
+
+```bash
+python server.py
+```
+
+The server will listen on port `8080` and expose the MCP stdio transport and
+an HTTP endpoint suitable for use with any MCP client.

--- a/boomi_mcp/__init__.py
+++ b/boomi_mcp/__init__.py
@@ -1,0 +1,1 @@
+"""Boomi MCP package."""

--- a/boomi_mcp/auth.py
+++ b/boomi_mcp/auth.py
@@ -1,0 +1,10 @@
+import os
+from boomi import Boomi
+
+def get_client() -> Boomi:
+    """Initialize and return a Boomi SDK client."""
+    return Boomi(
+        account=os.environ["BOOMI_ACCOUNT"],
+        user=os.environ["BOOMI_USER"],
+        secret=os.environ["BOOMI_SECRET"],
+    )

--- a/boomi_mcp/tools.py
+++ b/boomi_mcp/tools.py
@@ -1,0 +1,31 @@
+from pathlib import Path
+from fastmcp import FastMCP
+from .auth import get_client
+
+mcp = FastMCP(
+    name="Boomi MCP",
+    instructions=(
+        "Call these tools to interact with the Boomi Platform API. "
+        "NEVER ask the user for credentials."
+    ),
+)
+
+
+@mcp.tool()
+def create_component(xml_path: str) -> dict:
+    """Create a Boomi component from an XML file."""
+    boomi = get_client()
+    comp = boomi.components.create(Path(xml_path))
+    return comp.model_dump()
+
+
+@mcp.tool()
+def get_component(component_id: str) -> dict:
+    """Fetch a component by its Boomi ID."""
+    return get_client().components.get(component_id).model_dump()
+
+
+@mcp.tool()
+def deploy_package(environment_id: str, package_id: str) -> dict:
+    """Deploy an existing package to a target environment."""
+    return get_client().deployments.deploy(environment_id, package_id)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,18 @@
+[project]
+name = "boomi-mcp-server"
+version = "0.1.0"
+description = "MCP server exposing Boomi API via FastMCP"
+requires-python = ">=3.10"
+
+[project.dependencies]
+boomi = "*"
+fastmcp = "*"
+pydantic = "*"
+python-dotenv = "*"
+
+[project.scripts]
+boomi-mcp = "server:main"
+
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/server.py
+++ b/server.py
@@ -1,0 +1,11 @@
+from fastmcp.contrib.fastapi import serve
+from boomi_mcp.tools import mcp
+
+
+def main() -> None:
+    """Launch the MCP server."""
+    serve(mcp, host="0.0.0.0", port=8080)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add pyproject with boomi, fastmcp, pydantic dependencies
- implement auth helper and initial tools
- expose server via FastMCP
- document setup and usage

## Testing
- `git status --short`
