### PR TITLE
Add MCP discovery file

### DIFF
--- a/.well-known/mcp.json
+++ b/.well-known/mcp.json
@@ -1,0 +1,27 @@
+{
+  "tools": [
+    {
+      "name": "create_component",
+      "description": "Create a Boomi component from an XML file.",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "xml_path": { "type": "string", "description": "Path to the XML file" }
+        },
+        "required": ["xml_path"]
+      }
+    },
+    {
+      "name": "deploy_package",
+      "description": "Deploy a Boomi package to an environment.",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "environment_id": { "type": "string" },
+          "package_id": { "type": "string" }
+        },
+        "required": ["environment_id", "package_id"]
+      }
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -38,3 +38,7 @@ The server exposes most methods provided by the Boomi SDK, including helpers to:
 - Trigger process executions
 
 Run `tools/list` against the server to see the full list.
+
+A discovery file is available at `.well-known/mcp.json`.
+Run `python generate_mcp_json.py` to regenerate it from the MCP registry.
+

--- a/generate_mcp_json.py
+++ b/generate_mcp_json.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+import json
+
+from boomi_mcp.tools import mcp
+
+
+def main() -> None:
+    """Generate the discovery file from the FastMCP registry."""
+    specs = {"tools": mcp.get_tool_specs()}
+    path = Path(".well-known/mcp.json")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(specs, indent=2))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- provide `.well-known/mcp.json` for tool discovery
- add helper script to regenerate the discovery file
- document discovery file in README

## Testing
- `python -m py_compile generate_mcp_json.py`