### PR TITLE
Add initial test suite

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import sys
+from pathlib import Path
+
+# Ensure project root is on sys.path for tests when running via importlib mode
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,16 @@
+import os
+from boomi_mcp import auth
+
+class DummyBoomi:
+    def __init__(self, account, user, secret):
+        self.args = (account, user, secret)
+
+def test_get_client_uses_env(monkeypatch):
+    monkeypatch.setenv("BOOMI_ACCOUNT", "acct")
+    monkeypatch.setenv("BOOMI_USER", "user")
+    monkeypatch.setenv("BOOMI_SECRET", "secret")
+    monkeypatch.setattr(auth, "Boomi", DummyBoomi)
+
+    client = auth.get_client()
+    assert isinstance(client, DummyBoomi)
+    assert client.args == ("acct", "user", "secret")

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,0 +1,9 @@
+import asyncio
+from boomi_mcp.tools import mcp
+
+
+def test_create_component_tool_registered():
+    tools = asyncio.run(mcp.get_tools())
+    assert "create_component" in tools
+    tool = tools["create_component"]
+    assert tool.parameters["properties"]["xml_path"]["type"] == "string"


### PR DESCRIPTION
## Summary
- add test helper to ensure package import works
- test that authentication uses environment variables
- test FastMCP registry for expected tools

## Testing
- `pytest -q`