### PR TITLE
Add dotenv support

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,13 +19,15 @@ dependencies before running the installation command.
 
 ## Usage
 
-Set your Boomi credentials as environment variables:
+Set your Boomi credentials using environment variables or a `.env` file:
 
 ```bash
-export BOOMI_ACCOUNT=...
-export BOOMI_USER=...
-export BOOMI_SECRET=...
+BOOMI_ACCOUNT=...
+BOOMI_USER=...
+BOOMI_SECRET=...
 ```
+
+If a `.env` file exists in the working directory the server will load it automatically.
 
 Then start the server:
 

--- a/boomi_mcp/auth.py
+++ b/boomi_mcp/auth.py
@@ -1,8 +1,10 @@
 import os
+from dotenv import load_dotenv, find_dotenv
 from boomi import Boomi
 
 def get_client() -> Boomi:
     """Initialize and return a Boomi SDK client."""
+    load_dotenv(find_dotenv(usecwd=True))
     return Boomi(
         account=os.environ["BOOMI_ACCOUNT"],
         user=os.environ["BOOMI_USER"],

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -14,3 +14,17 @@ def test_get_client_uses_env(monkeypatch):
     client = auth.get_client()
     assert isinstance(client, DummyBoomi)
     assert client.args == ("acct", "user", "secret")
+
+
+def test_get_client_loads_dotenv(monkeypatch, tmp_path):
+    env_file = tmp_path / ".env"
+    env_file.write_text("BOOMI_ACCOUNT=acct\nBOOMI_USER=user\nBOOMI_SECRET=secret\n")
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("BOOMI_ACCOUNT", raising=False)
+    monkeypatch.delenv("BOOMI_USER", raising=False)
+    monkeypatch.delenv("BOOMI_SECRET", raising=False)
+    monkeypatch.setattr(auth, "Boomi", DummyBoomi)
+
+    client = auth.get_client()
+    assert isinstance(client, DummyBoomi)
+    assert client.args == ("acct", "user", "secret")


### PR DESCRIPTION
## Summary
- load `.env` file when authenticating
- mention `.env` support in docs
- test reading credentials from `.env`

## Testing
- `pytest -q`