### PR TITLE
Allow configuring server port

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,12 +6,12 @@ readme = "README.md"
 license = { file = "LICENSE" }
 authors = [{ name = "Glebuar" }]
 requires-python = ">=3.10"
-
-[project.dependencies]
-boomi = "*"
-fastmcp = "*"
-pydantic = "*"
-python-dotenv = "*"
+dependencies = [
+    "boomi",
+    "fastmcp",
+    "pydantic",
+    "python-dotenv",
+]
 
 [project.scripts]
 boomi-mcp = "server:main"

--- a/server.py
+++ b/server.py
@@ -1,10 +1,32 @@
-from fastmcp.contrib.fastapi import serve
+"""Simple entry point for running the Boomi MCP server."""
+
+import argparse
+import os
+
+import uvicorn
 from boomi_mcp.tools import mcp
+
+
+app = mcp.http_app()
 
 
 def main() -> None:
     """Launch the MCP server."""
-    serve(mcp, host="0.0.0.0", port=8080)
+    parser = argparse.ArgumentParser(description="Start the Boomi MCP server")
+    parser.add_argument(
+        "--host",
+        default=os.getenv("HOST", "0.0.0.0"),
+        help="Address to bind (default: env HOST or 0.0.0.0)",
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=int(os.getenv("PORT", 8080)),
+        help="Port to listen on (default: env PORT or 8080)",
+    )
+    args = parser.parse_args()
+
+    uvicorn.run(app, host=args.host, port=args.port)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- allow specifying server host and port via command line or environment variables

## Testing
- `pytest -q`
