### PR TITLE
Cursor compatibility and cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - run: pip install -e .[dev]
+      - run: pytest

--- a/.well-known/mcp.json
+++ b/.well-known/mcp.json
@@ -1,9 +1,10 @@
 {
   "mcpServers": {
-    "server-name": {
+    "boomi": {
       "command": "python",
-      "args": ["server.py"]
-      
+      "args": ["server.py"],
+      "type": "stdio",
+      "cwd": "${workspaceFolder}"
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Boomi MCP Server
 
+[![CI](https://github.com/glebuar/boomi-mcp-server/actions/workflows/ci.yml/badge.svg)](https://github.com/glebuar/boomi-mcp-server/actions/workflows/ci.yml)
+[![PyPI](https://img.shields.io/pypi/v/boomi-mcp-server.svg)](https://pypi.org/project/boomi-mcp-server/)
+[![License](https://img.shields.io/github/license/glebuar/boomi-mcp-server.svg)](LICENSE)
+
 This repository provides a simple [Model Context Protocol](https://modelcontextprotocol.io) (MCP) server for interacting with the Boomi API. The server exposes Boomi SDK operations as MCP tools using [FastMCP](https://pypi.org/project/fastmcp/).
 
 ## Requirements
@@ -7,10 +11,11 @@ This repository provides a simple [Model Context Protocol](https://modelcontextp
 - Python 3.10+
 - Access credentials for the Boomi API
 
-Install the package directly from PyPI:
+Install the package directly from PyPI or from source:
 
 ```bash
 pip install boomi-mcp-server
+# or clone & pip install -e .
 ```
 
 The server depends on the `boomi` and `uvicorn` packages from PyPI. If your
@@ -29,10 +34,16 @@ BOOMI_SECRET=...
 
 If a `.env` file exists in the working directory the server will load it automatically.
 
-Then start the server:
+Start the server in stdio mode (for Cursor and most hosts):
 
 ```bash
 python server.py
+```
+
+For development you can run an SSE HTTP server:
+
+```bash
+python server.py --transport sse --port 8080
 ```
 
 The server exposes most methods provided by the Boomi SDK, including helpers to:
@@ -45,4 +56,6 @@ The server exposes most methods provided by the Boomi SDK, including helpers to:
 
 Run `tools/list` against the server to see the full list.
 
-A discovery file is available at `.well-known/mcp.json`.
+A discovery file is available at `.well-known/mcp.json`. See
+[docs/cursor_setup.md](docs/cursor_setup.md) for instructions on using it
+with Cursor.

--- a/boomi_mcp/__init__.py
+++ b/boomi_mcp/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"

--- a/boomi_mcp/auth.py
+++ b/boomi_mcp/auth.py
@@ -2,10 +2,12 @@ import os
 from dotenv import load_dotenv
 from boomi import Boomi
 
-load_dotenv()
+def _load_env() -> None:
+    load_dotenv(dotenv_path='.env', override=False)
 
 def get_client() -> Boomi:
     """Initialize and return a Boomi SDK client."""
+    _load_env()
     return Boomi(
         account=os.environ["BOOMI_ACCOUNT"],
         user=os.environ["BOOMI_USER"],

--- a/boomi_mcp/server.py
+++ b/boomi_mcp/server.py
@@ -1,0 +1,40 @@
+import argparse
+import logging
+import os
+import sys
+
+from dotenv import load_dotenv
+from fastmcp import __version__ as fastmcp_version
+from boomi_mcp.tools import mcp
+
+
+logger = logging.getLogger(__name__)
+
+
+def _check_env() -> None:
+    missing = [v for v in ("BOOMI_ACCOUNT", "BOOMI_USER", "BOOMI_SECRET") if v not in os.environ]
+    if missing:
+        logger.warning("Missing Boomi credentials: %s", ", ".join(missing))
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Boomi MCP Server")
+    parser.add_argument("--transport", choices=["stdio", "sse"], default="stdio")
+    parser.add_argument("--port", type=int, default=8080, help="Port for SSE mode")
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(level=logging.INFO, stream=sys.stderr)
+    for name in ("uvicorn", "fastapi"):
+        logging.getLogger(name).handlers = []
+
+    load_dotenv()
+    _check_env()
+
+    if args.transport == "stdio":
+        mcp.run(transport="stdio")
+    else:
+        mcp.run(transport="sse", port=args.port)
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/cursor_setup.md
+++ b/docs/cursor_setup.md
@@ -1,0 +1,6 @@
+# Using Boomi MCP Server with Cursor
+
+1. Copy the JSON snippet from `.well-known/mcp.json` into your Cursor `mcp.json`.
+2. Reload MCP servers in Cursor.
+3. Enable **boomi** from the list.
+4. Provide your Boomi credentials via Cursor Settings → MCP → Env.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "boomi-mcp-server"
-version = "0.1.0"
+version = "0.2.0"
 description = "MCP server exposing Boomi API via FastMCP"
 readme = "README.md"
 license = { file = "LICENSE" }
@@ -15,7 +15,13 @@ dependencies = [
 ]
 
 [project.scripts]
-boomi-mcp = "server:main"
+boomi-mcp = "boomi_mcp.server:main"
+
+[project.optional-dependencies]
+dev = [
+    "pytest",
+    "httpx",
+]
 
 [build-system]
 requires = ["setuptools", "wheel"]

--- a/server.py
+++ b/server.py
@@ -1,11 +1,4 @@
-from fastmcp.contrib.fastapi import serve
-from boomi_mcp.tools import mcp
-
-
-def main() -> None:
-    """Launch the MCP server."""
-    serve(mcp, host="0.0.0.0", port=8080)
-
+from boomi_mcp.server import main
 
 if __name__ == "__main__":
     main()

--- a/tests/test_env_warning.py
+++ b/tests/test_env_warning.py
@@ -1,0 +1,26 @@
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+
+def test_warn_missing_env(monkeypatch):
+    root = Path(__file__).resolve().parents[1]
+    monkeypatch.delenv("BOOMI_ACCOUNT", raising=False)
+    monkeypatch.delenv("BOOMI_USER", raising=False)
+    monkeypatch.delenv("BOOMI_SECRET", raising=False)
+    proc = subprocess.Popen(
+        [sys.executable, "server.py"],
+        cwd=root,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    try:
+        time.sleep(0.5)
+        stderr_line = proc.stderr.readline()
+        assert "Missing Boomi credentials" in stderr_line
+    finally:
+        proc.terminate()
+        proc.wait(timeout=5)


### PR DESCRIPTION
## Summary
- use stdio runtime by default
- add CLI flag for SSE dev mode and log env warnings
- update discovery configuration and docs for Cursor
- add GitHub Actions test workflow
- add tests for missing env

## Testing
- `pytest -q`
