### PR TITLE
Add missing fastmcp dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ requires-python = ">=3.10"
 
 dependencies = [
     "boomi",
+    "fastmcp",
     "uvicorn",
     "pydantic",
     "python-dotenv",


### PR DESCRIPTION
## Summary
- include `fastmcp` in the project dependencies

## Testing
- `pytest -q`