### PR TITLE
Improve config validation and add health check

### DIFF
--- a/.well-known/mcp.json
+++ b/.well-known/mcp.json
@@ -1,6 +1,8 @@
 {
   "mcpServers": {
     "boomi": {
+      "displayName": "Boomi MCP Server",
+      "description": "Interact with the Boomi Platform via MCP.",
       "command": "python",
       "args": ["server.py"],
       "type": "stdio",

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Start the server in stdio mode (for Cursor and most hosts):
 ```bash
 python server.py
 ```
+On Windows, use `pythonw` instead of `python` to avoid a console window.
 
 For development you can run an SSE HTTP server:
 

--- a/src/custom_session.py
+++ b/src/custom_session.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import logging
+
+from mcp.shared.session import RequestResponder
+from mcp.server.session import ServerSession
+import mcp.types as types
+
+logger = logging.getLogger(__name__)
+
+
+class PatchedServerSession(ServerSession):
+    """ServerSession that gracefully handles unsupported requests."""
+
+    async def _receive_loop(self) -> None:  # noqa: C901 - lengthy but matches base
+        async with (
+            self._read_stream,
+            self._write_stream,
+        ):
+            async for message in self._read_stream:
+                if isinstance(message, Exception):
+                    await self._handle_incoming(message)
+                elif isinstance(message.message.root, types.JSONRPCRequest):
+                    raw = message.message.root
+                    try:
+                        validated_request = self._receive_request_type.model_validate(
+                            raw.model_dump(by_alias=True, mode="json", exclude_none=True)
+                        )
+                    except Exception:
+                        method = raw.method
+                        if method in {"models/load", "contexts/switch"}:
+                            await self._send_response(
+                                raw.id,
+                                types.ErrorData(
+                                    code=types.METHOD_NOT_FOUND,
+                                    message=f"{method} not supported",
+                                ),
+                            )
+                        else:
+                            await self._send_response(
+                                raw.id,
+                                types.ErrorData(code=types.METHOD_NOT_FOUND, message="Method not found"),
+                            )
+                        continue
+                    responder = RequestResponder(
+                        request_id=raw.id,
+                        request_meta=validated_request.root.params.meta
+                        if validated_request.root.params
+                        else None,
+                        request=validated_request,
+                        session=self,
+                        on_complete=lambda r: self._in_flight.pop(r.request_id, None),
+                    )
+
+                    self._in_flight[responder.request_id] = responder
+                    await self._received_request(responder)
+
+                    if not responder._completed:
+                        await self._handle_incoming(responder)
+                elif isinstance(message.message.root, types.JSONRPCNotification):
+                    try:
+                        notification = self._receive_notification_type.model_validate(
+                            message.message.root.model_dump(by_alias=True, mode="json", exclude_none=True)
+                        )
+                        if isinstance(notification.root, types.CancelledNotification):
+                            cancelled_id = notification.root.params.requestId
+                            if cancelled_id in self._in_flight:
+                                await self._in_flight[cancelled_id].cancel()
+                        else:
+                            if isinstance(notification.root, types.ProgressNotification):
+                                progress_token = notification.root.params.progressToken
+                                if progress_token in self._progress_callbacks:
+                                    callback = self._progress_callbacks[progress_token]
+                                    await callback(
+                                        notification.root.params.progress,
+                                        notification.root.params.total,
+                                        notification.root.params.message,
+                                    )
+                            await self._received_notification(notification)
+                            await self._handle_incoming(notification)
+                    except Exception as e:  # pragma: no cover - unexpected
+                        logger.warning(
+                            "Failed to validate notification: %s. Message was: %s",
+                            e,
+                            message.message.root,
+                        )
+                else:
+                    stream = self._response_streams.pop(message.message.root.id, None)
+                    if stream:
+                        await stream.send(message.message.root)
+                    else:
+                        await self._handle_incoming(
+                            RuntimeError(
+                                "Received response with an unknown request ID: %s" % message,
+                            )
+                        )

--- a/src/server.py
+++ b/src/server.py
@@ -6,6 +6,8 @@ import sys
 from dotenv import load_dotenv
 from fastmcp import __version__ as fastmcp_version
 from .tools import mcp
+from .custom_session import PatchedServerSession
+from mcp import server as mcp_server
 
 
 logger = logging.getLogger(__name__)
@@ -14,7 +16,9 @@ logger = logging.getLogger(__name__)
 def _check_env() -> None:
     missing = [v for v in ("BOOMI_ACCOUNT", "BOOMI_USER", "BOOMI_SECRET") if v not in os.environ]
     if missing:
-        logger.warning("Missing Boomi credentials: %s", ", ".join(missing))
+        msg = f"Missing Boomi credentials: {', '.join(missing)}"
+        logger.error(msg)
+        raise EnvironmentError(msg)
 
 
 def main(argv: list[str] | None = None) -> None:
@@ -26,6 +30,9 @@ def main(argv: list[str] | None = None) -> None:
     logging.basicConfig(level=logging.INFO, stream=sys.stderr)
     for name in ("uvicorn", "fastapi"):
         logging.getLogger(name).handlers = []
+
+    # Use patched session to gracefully handle unsupported requests
+    mcp_server.session.ServerSession = PatchedServerSession
 
     load_dotenv()
     _check_env()

--- a/src/tools.py
+++ b/src/tools.py
@@ -12,8 +12,14 @@ mcp = FastMCP(
 
 
 @mcp.tool()
+def health_check() -> bool:
+    """Simple connectivity check returning ``True`` when the server is alive."""
+    return True
+
+
+@mcp.tool()
 def create_component(xml_path: str) -> dict:
-    """Create a Boomi component from an XML file."""
+    """Create a new component in Boomi from the provided XML definition."""
     boomi = get_client()
     comp = boomi.components.create(Path(xml_path))
     return comp.model_dump()
@@ -21,86 +27,86 @@ def create_component(xml_path: str) -> dict:
 
 @mcp.tool()
 def update_component(component_id: str, xml: str) -> None:
-    """Update a component's XML."""
+    """Replace the XML configuration for an existing component."""
     get_client().components.update(component_id, xml)
 
 
 @mcp.tool()
 def delete_component(component_id: str) -> None:
-    """Delete a component by ID."""
+    """Remove a component from the account using its ID."""
     get_client().components.delete(component_id)
 
 
 @mcp.tool()
 def get_component(component_id: str) -> dict:
-    """Fetch a component by its Boomi ID."""
+    """Retrieve a component's metadata and XML by ID."""
     return get_client().components.get(component_id).model_dump()
 
 
 @mcp.tool()
 def create_package(component_id: str, package_version: str | None = None,
                     notes: str | None = None) -> dict:
-    """Create a package from a component."""
+    """Package a component for deployment, optionally setting a version."""
     return get_client().packages.create(component_id, package_version, notes)
 
 
 @mcp.tool()
 def deploy_package(environment_id: str, package_id: str) -> dict:
-    """Deploy an existing package to a target environment."""
+    """Deploy a previously created package to an environment."""
     return get_client().deployments.deploy(environment_id, package_id)
 
 
 @mcp.tool()
 def create_folder(name: str, parent_id: str | None = None) -> dict:
-    """Create a folder."""
+    """Create a new folder optionally under ``parent_id``."""
     return get_client().folders.create(name, parent_id)
 
 
 @mcp.tool()
 def get_folder(folder_id: str) -> dict:
-    """Fetch a folder by ID."""
+    """Return folder details for the given ID."""
     return get_client().folders.get(folder_id)
 
 
 @mcp.tool()
 def delete_folder(folder_id: str) -> None:
-    """Delete a folder."""
+    """Delete an existing folder by ID."""
     get_client().folders.delete(folder_id)
 
 
 @mcp.tool()
 def list_atoms() -> list:
-    """List available atoms."""
+    """List all atoms available to the account."""
     return get_client().atoms.list()
 
 
 @mcp.tool()
 def list_environments() -> list:
-    """List environments."""
+    """List all deployment environments in the connected Boomi account."""
     return get_client().environments.list()
 
 
 @mcp.tool()
 def query_runs(query: dict) -> dict:
-    """Query execution records."""
+    """Search for execution records matching the provided query."""
     return get_client().runs.list(query)
 
 
 @mcp.tool()
 def get_run_log(execution_id: str) -> str:
-    """Get a URL to the execution log."""
+    """Return a URL pointing to the log for the given execution."""
     return get_client().runs.log(execution_id)
 
 
 @mcp.tool()
 def query_runs_more(token: str) -> dict:
-    """Fetch additional execution records using a query token."""
+    """Continue a previous execution query using the pagination token."""
     return get_client().runs.list_more(token)
 
 
 @mcp.tool()
 def query_run_summary(query: dict) -> dict:
-    """Query execution summary records."""
+    """Retrieve summarized statistics for executions matching a query."""
     return get_client().runs.summary(query)
 
 

--- a/tests/test_env_warning.py
+++ b/tests/test_env_warning.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import os
 
 
-def test_warn_missing_env(monkeypatch):
+def test_fail_missing_env(monkeypatch):
     root = Path(__file__).resolve().parents[1]
     monkeypatch.delenv("BOOMI_ACCOUNT", raising=False)
     monkeypatch.delenv("BOOMI_USER", raising=False)
@@ -15,16 +15,11 @@ def test_warn_missing_env(monkeypatch):
     proc = subprocess.Popen(
         [sys.executable, "server.py"],
         cwd=root,
-        stdin=subprocess.PIPE,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         text=True,
         env=env,
     )
-    try:
-        time.sleep(0.5)
-        stderr_line = proc.stderr.readline()
-        assert "Missing Boomi credentials" in stderr_line
-    finally:
-        proc.terminate()
-        proc.wait(timeout=5)
+    stdout, stderr = proc.communicate(timeout=5)
+    assert proc.returncode != 0
+    assert "Missing Boomi credentials" in stderr

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -7,3 +7,8 @@ def test_create_component_tool_registered():
     assert "create_component" in tools
     tool = tools["create_component"]
     assert tool.parameters["properties"]["xml_path"]["type"] == "string"
+
+
+def test_health_check_tool_registered():
+    tools = asyncio.run(mcp.get_tools())
+    assert "health_check" in tools


### PR DESCRIPTION
## Summary
- add Windows note to README
- expand `.well-known/mcp.json` with metadata
- validate startup env vars strictly
- handle unsupported MCP requests gracefully
- add a `health_check` tool and improve descriptions
- provide unit tests for new behaviour

## Testing
- `pytest -q`