### PR TITLE
Update docs for uv launcher

### DIFF
--- a/.github/workflows/lint-examples.yml
+++ b/.github/workflows/lint-examples.yml
@@ -1,0 +1,18 @@
+name: Lint examples
+
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Run example checks
+        run: |
+          python scripts/check_examples.py examples/mcp.json.windows examples/mcp.json.linux

--- a/.well-known/mcp.json
+++ b/.well-known/mcp.json
@@ -1,12 +1,13 @@
 {
   "mcpServers": {
     "boomi": {
-      "displayName": "Boomi MCP Server",
-      "description": "Interact with the Boomi Platform via MCP.",
-      "command": "python",
-      "args": ["server.py"],
-      "type": "stdio",
-      "cwd": "${workspaceFolder}"
+      "command": "uv",
+      "args": [
+        "--directory",
+        "${workspaceFolder}",
+        "run",
+        "src/server.py"
+      ]
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ This repository provides a simple [Model Context Protocol](https://modelcontextp
 - Python 3.10+
 - Access credentials for the Boomi API
 
-Install the package directly from PyPI or from source:
+Install the server and the `uv` launcher from PyPI:
 
 ```bash
-pip install boomi-mcp-server
+pip install boomi-mcp-server uv
 # or clone & pip install -e .
 ```
 
@@ -34,16 +34,66 @@ BOOMI_SECRET=...
 
 If a `.env` file exists in the working directory the server will load it automatically.
 
+## Running with uv (Claude for Desktop)
+
+`uv` provides fast cold starts and isolates dependencies in a temporary virtual environment. MCP servers started with `uv` also comply with the latest MCP specification.
+
+Claude Desktop reads its configuration from `claude_desktop_config.json`:
+`~/Library/Application Support/Claude` on macOS or `%AppData%\Claude` on Windows.
+Create or edit this file to add a server entry as shown below, then restart Claude.
+
+Add a server entry in your `mcp.json` using absolute paths only. Example configurations are available under the [`examples`](examples) folder.
+
+Windows:
+
+```jsonc
+// mcp.json
+{
+  "mcpServers": {
+    "boomi": {
+      "command": "uv",
+      "args": [
+        "--directory",
+        "C:\\ABSOLUTE\\PATH\\TO\\boomi-mcp-server",
+        "run",
+        "src/server.py"
+      ]
+    }
+  }
+}
+```
+
+macOS/Linux:
+
+```jsonc
+// mcp.json
+{
+  "mcpServers": {
+    "boomi": {
+      "command": "uv",
+      "args": [
+        "--directory",
+        "/ABSOLUTE/PATH/TO/boomi-mcp-server",
+        "run",
+        "src/server.py"
+      ]
+    }
+  }
+}
+```
+
+Only the `command` and `args` keys are supported when launching from Claude. If `uv` is not in your `PATH`, replace it with the full path returned by `where uv` (Windows) or `which uv` (macOS/Linux). Restart Claude after updating `mcp.json`.
+
 Start the server in stdio mode (for Cursor and most hosts):
 
 ```bash
-python server.py
+uv run src/server.py
 ```
 
 For development you can run an SSE HTTP server:
 
 ```bash
-python server.py --transport sse --port 8080
+uv run src/server.py -- --transport sse --port 8080
 ```
 
 The server exposes most methods provided by the Boomi SDK, including helpers to:

--- a/examples/mcp.json.linux
+++ b/examples/mcp.json.linux
@@ -1,0 +1,15 @@
+// Replace with the absolute path to your cloned boomi-mcp-server repository.
+// If 'uv' is not in PATH, use the full path from 'which uv'.
+{
+    "mcpServers": {
+        "boomi": {
+            "command": "uv",
+            "args": [
+                "--directory",
+                "/ABSOLUTE/PATH/TO/boomi-mcp-server",
+                "run",
+                "src/server.py"
+            ]
+        }
+    }
+}

--- a/examples/mcp.json.windows
+++ b/examples/mcp.json.windows
@@ -1,0 +1,15 @@
+// Replace with the absolute path to your cloned boomi-mcp-server repository.
+// If 'uv' is not in PATH, use the full path from 'where uv' or 'which uv'.
+{
+    "mcpServers": {
+        "boomi": {
+            "command": "uv",
+            "args": [
+                "--directory",
+                "C:\\ABSOLUTE\\PATH\\TO\\boomi-mcp-server",
+                "run",
+                "src/server.py"
+            ]
+        }
+    }
+}

--- a/scripts/check_examples.py
+++ b/scripts/check_examples.py
@@ -1,0 +1,52 @@
+import json
+import sys
+from pathlib import Path
+
+
+def load_json_with_comments(path: Path):
+    lines = []
+    for line in path.read_text().splitlines():
+        stripped = line.strip()
+        if stripped.startswith('//') or stripped.startswith('#') or not stripped:
+            continue
+        lines.append(line)
+    return json.loads('\n'.join(lines))
+
+
+def is_absolute(arg: str) -> bool:
+    if arg.startswith('/'):
+        return True
+    if len(arg) > 1 and arg[1] == ':' and arg[2:3] in ('\\', '/'):
+        return True
+    return False
+
+
+def check_file(path: Path) -> int:
+    try:
+        data = load_json_with_comments(path)
+    except json.JSONDecodeError as e:
+        print(f"{path}: invalid JSON - {e}")
+        return 1
+    try:
+        args = data['mcpServers']['boomi']['args']
+    except KeyError as e:
+        print(f"{path}: missing key {e}")
+        return 1
+    # Ensure '--directory' is followed by absolute path
+    if '--directory' in args:
+        idx = args.index('--directory') + 1
+        if idx >= len(args) or not is_absolute(args[idx]):
+            print(f"{path}: '--directory' must be followed by an absolute path")
+            return 1
+    return 0
+
+
+def main(paths):
+    ret = 0
+    for p in paths:
+        ret |= check_file(Path(p))
+    return ret
+
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
## Summary
- remove stale `CHANGELOG.md`
- document uv installation and Claude Desktop config paths
- update examples and discovery JSON to use `uv` and `src/server.py`

## Testing
- `pip install -e .[dev] --no-build-isolation`
- `pytest -q`
- `python scripts/check_examples.py examples/mcp.json.windows examples/mcp.json.linux`
