### PR TITLE
Expand docs and CI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# Copy this file to .env and fill in your Boomi API credentials
+BOOMI_ACCOUNT=<your_account_id>
+BOOMI_USER=<your_username_or_email>
+BOOMI_SECRET=<your_api_token>

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,3 +18,20 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - run: pip install -e .[dev]
       - run: pytest
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - run: pip install ruff
+      - run: ruff check .
+
+  docker-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build Docker image
+        run: docker build -t boomi-mcp-server .

--- a/README.md
+++ b/README.md
@@ -6,6 +6,17 @@
 
 This repository provides a simple [Model Context Protocol](https://modelcontextprotocol.io) (MCP) server for interacting with the Boomi API. The server exposes Boomi SDK operations as MCP tools using [FastMCP](https://pypi.org/project/fastmcp/).
 
+## Table of Contents
+
+- [Requirements](#requirements)
+- [Quick start](#quick-start)
+- [Usage](#usage)
+- [Running with uv (Claude for Desktop)](#running-with-uv-claude-for-desktop)
+- [Running via Docker](#running-via-docker)
+- [Cursor/Claude Setup](docs/cursor_setup.md)
+- [Running tests](#running-tests)
+- [Contributing](#contributing)
+
 ## Requirements
 
 - Python 3.10+
@@ -42,7 +53,8 @@ dependencies before running the installation command.
 
 ## Usage
 
-Set your Boomi credentials using environment variables or a `.env` file:
+Set your Boomi credentials using environment variables or a `.env` file
+(copy the provided `.env.example` and fill in your values):
 
 ```bash
 BOOMI_ACCOUNT=...
@@ -65,6 +77,9 @@ print(client.list_tools())
 result = client.call_tool("health_check")
 print(result)
 ```
+
+See [`examples/using_client.py`](examples/using_client.py) for a complete script
+demonstrating these calls.
 
 
 ## Running with uv (Claude for Desktop)
@@ -171,3 +186,8 @@ dependencies and run them with `pytest`:
 pip install -e .[dev]      # or `uv pip install -e .[dev]`
 pytest
 ```
+
+## Contributing
+
+Please open an issue or pull request if you encounter problems or have
+improvements. Ensure `pytest` and `ruff` pass before submitting changes.

--- a/docs/cursor_setup.md
+++ b/docs/cursor_setup.md
@@ -1,6 +1,115 @@
-# Using Boomi MCP Server with Cursor
+# Integrating Boomi MCP Server with Cursor and Claude Desktop
 
-1. Copy the JSON snippet from `.well-known/mcp.json` into your Cursor `mcp.json`.
-2. Reload MCP servers in Cursor.
-3. Enable **boomi** from the list.
-4. Provide your Boomi credentials via Cursor Settings → MCP → Env.
+This guide walks through adding the Boomi MCP Server to both Cursor (the AI code
+editor) and Claude Desktop.
+
+## Configuration file locations
+
+### Cursor
+
+- **macOS:** `~/Library/Application Support/Cursor`
+- **Windows:** `%AppData%\Cursor`
+- **Linux:** `~/.config/Cursor`
+
+`mcp.json` lives in this directory.
+
+### Claude Desktop
+
+- **macOS:** `~/Library/Application Support/Claude`
+- **Windows:** `%AppData%\Claude`
+
+Claude reads `claude_desktop_config.json` from this folder.
+
+## Adding the server entry
+
+1. Copy the contents of `.well-known/mcp.json` from this repository:
+
+```jsonc
+{
+  "mcpServers": {
+    "boomi": {
+      "command": "uv",
+      "args": [
+        "--directory",
+        "${workspaceFolder}",
+        "run",
+        "boomi_mcp_server/server.py"
+      ]
+    }
+  }
+}
+```
+
+`${workspaceFolder}` will be replaced with the absolute path to the repository
+when used by the host application.
+
+2. Merge this block into your host's configuration file:
+   - For **Cursor**, edit `mcp.json` in the directory listed above.
+   - For **Claude Desktop**, open `claude_desktop_config.json` and add the entry
+     under the `"mcpServers"` section.
+
+3. If `uv` is not in your `PATH`, replace it with the full path returned by
+   `which uv` (macOS/Linux) or `where uv` (Windows).
+
+4. Restart Cursor or Claude and enable the **boomi** server entry.
+
+## Example `mcp.json` entries
+
+Example configuration files are available under the [`examples`](../examples)
+folder. They demonstrate using absolute paths on each platform.
+
+Windows:
+
+```jsonc
+{
+  "mcpServers": {
+    "boomi": {
+      "command": "uv",
+      "args": [
+        "--directory",
+        "C:\\ABSOLUTE\\PATH\\TO\\boomi-mcp-server",
+        "run",
+        "boomi_mcp_server/server.py"
+      ]
+    }
+  }
+}
+```
+
+macOS/Linux:
+
+```jsonc
+{
+  "mcpServers": {
+    "boomi": {
+      "command": "uv",
+      "args": [
+        "--directory",
+        "/ABSOLUTE/PATH/TO/boomi-mcp-server",
+        "run",
+        "boomi_mcp_server/server.py"
+      ]
+    }
+  }
+}
+```
+
+Absolute paths are required. If the `uv` binary is not in your `PATH`, specify
+the full path instead.
+
+## Troubleshooting
+
+- **Port conflicts:** the server runs on port `8080` in SSE mode by default. If
+  the port is already in use, add `"--port", "9090"` to the `args` list and
+  update the URL in your client configuration.
+- **Docker network/firewall:** when running via Docker, ensure that localhost
+  ports are accessible. Windows may prompt for firewall access the first time
+  the container starts.
+- **Missing credentials:** if the server exits with a "Missing Boomi
+  credentials" error, set the `BOOMI_ACCOUNT`, `BOOMI_USER` and `BOOMI_SECRET`
+  environment variables. Cursor and Claude let you specify these in their
+  settings UI or you can provide a `.env` file in the working directory.
+- **Configuration differences:** Cursor reads `mcp.json` while Claude Desktop
+  uses `claude_desktop_config.json`. Both require absolute paths and support
+  only the `command` and `args` fields.
+

--- a/examples/using_client.py
+++ b/examples/using_client.py
@@ -1,0 +1,13 @@
+"""Example usage of the MCP client."""
+from boomi_mcp_client import MCPClient
+
+# assumes the server is running on localhost:8080 in SSE mode
+client = MCPClient("http://localhost:8080")
+
+# List available tools
+tools = client.list_tools()
+print("Available tools:", [t["name"] for t in tools])
+
+# Call the health_check tool
+result = client.call_tool("health_check")
+print("Health check result:", result)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,16 @@ license = { file = "LICENSE" }
 authors = [{ name = "Glebuar" }]
 requires-python = ">=3.10"
 
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Intended Audience :: Developers",
+    "Topic :: Software Development :: Libraries",
+]
+
 dependencies = [
     "boomi",
     "fastmcp",
@@ -22,6 +32,7 @@ boomi-mcp = "boomi_mcp_server.server:main"
 dev = [
     "pytest",
     "httpx",
+    "ruff",
 ]
 
 [build-system]
@@ -31,3 +42,6 @@ build-backend = "setuptools.build_meta"
 [tool.setuptools.packages.find]
 where = ["src"]
 include = ["boomi_mcp_server*", "boomi_mcp_client*"]
+
+[tool.ruff]
+line-length = 88

--- a/server.py
+++ b/server.py
@@ -1,4 +1,0 @@
-from boomi_mcp_server.server import main
-
-if __name__ == "__main__":
-    main()

--- a/src/boomi_mcp_server/server.py
+++ b/src/boomi_mcp_server/server.py
@@ -4,7 +4,6 @@ import os
 import sys
 
 from dotenv import load_dotenv
-from fastmcp import __version__ as fastmcp_version
 from .tools import mcp
 from .custom_session import PatchedServerSession
 from mcp import server as mcp_server

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,4 +1,3 @@
-import os
 from boomi_mcp_server import auth
 
 class DummyBoomi:

--- a/tests/test_env_warning.py
+++ b/tests/test_env_warning.py
@@ -1,6 +1,5 @@
 import subprocess
 import sys
-import time
 from pathlib import Path
 import os
 
@@ -13,7 +12,7 @@ def test_fail_missing_env(monkeypatch):
     env = os.environ.copy()
     env["PYTHONPATH"] = os.pathsep.join([str(root), str(root / "src")])
     proc = subprocess.Popen(
-        [sys.executable, "server.py"],
+        [sys.executable, "-m", "boomi_mcp_server.server"],
         cwd=root,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,


### PR DESCRIPTION
## Summary
- add integration docs for Cursor and Claude Desktop
- provide sample environment file and Python client example
- remove unused wrapper script and update tests
- add ruff linting and Docker build to CI
- document contributing and table of contents
- fix CI lint command

## Testing
- `ruff check .`
- `pip install -e .[dev]` *(fails: Could not install build dependencies)*
- `pytest`
