### PR TITLE
I've focused on improving clarity and consistency in your documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ uv venv
 source .venv/bin/activate     # or .venv\Scripts\activate on Windows
 uv lock
 ```
+Running `uv lock` is a recommended step to ensure reproducible environments by locking dependencies, but it's not strictly required for basic server operation if you prefer to use the latest compatible versions.
 
 You can also install the server directly from PyPI:
 
@@ -82,13 +83,13 @@ See [`examples/using_client.py`](examples/using_client.py) for a complete script
 demonstrating these calls.
 
 
-## Running with uv (Claude for Desktop)
+## Running with uv (Claude Desktop)
 
 `uv` provides fast cold starts and isolates dependencies in a temporary virtual environment. MCP servers started with `uv` also comply with the latest MCP specification.
 
 Claude Desktop reads its configuration from `claude_desktop_config.json`:
 `~/Library/Application Support/Claude` on macOS or `%AppData%\Claude` on Windows.
-Create or edit this file to add a server entry as shown below, then restart Claude.
+Create or edit this file to add a server entry as shown below, then restart Claude Desktop.
 
 Add a server entry in your `mcp.json` using absolute paths only. Example configurations are available under the [`examples`](examples) folder.
 
@@ -130,7 +131,7 @@ macOS/Linux:
 }
 ```
 
-Only the `command` and `args` keys are supported when launching from Claude. If `uv` is not in your `PATH`, replace it with the full path returned by `where uv` (Windows) or `which uv` (macOS/Linux). Restart Claude after updating `mcp.json`.
+Note: `${workspaceFolder}` is a placeholder that should be replaced with the absolute path to the `boomi-mcp-server` directory if your host application does not support this variable. Alternatively, you can use the example configurations from the `examples/` folder which use absolute paths. Only the `command` and `args` keys are supported when launching from Claude Desktop. If `uv` is not in your `PATH`, replace `uv` with the full path to the `uv` executable. Restart Claude Desktop after updating `mcp.json`.
 
 Start the server in stdio mode (for Cursor and most hosts):
 
@@ -175,7 +176,7 @@ Run `tools/list` against the server to see the full list.
 
 A discovery file is available at `.well-known/mcp.json`. See
 [docs/cursor_setup.md](docs/cursor_setup.md) for instructions on using it
-with Cursor.
+with Cursor/Claude Desktop.
 
 ## Running tests
 

--- a/docs/cursor_setup.md
+++ b/docs/cursor_setup.md
@@ -40,18 +40,14 @@ Claude reads `claude_desktop_config.json` from this folder.
 }
 ```
 
-`${workspaceFolder}` will be replaced with the absolute path to the repository
-when used by the host application.
+Note: You will need to replace `"${workspaceFolder}"` with the actual absolute path to the `boomi-mcp-server` repository directory. See the examples below for platform-specific guidance. If `uv` is not in your `PATH`, replace `uv` with the full path to the `uv` executable.
 
 2. Merge this block into your host's configuration file:
    - For **Cursor**, edit `mcp.json` in the directory listed above.
    - For **Claude Desktop**, open `claude_desktop_config.json` and add the entry
      under the `"mcpServers"` section.
 
-3. If `uv` is not in your `PATH`, replace it with the full path returned by
-   `which uv` (macOS/Linux) or `where uv` (Windows).
-
-4. Restart Cursor or Claude and enable the **boomi** server entry.
+3. Restart Cursor or Claude Desktop and enable the **boomi** server entry.
 
 ## Example `mcp.json` entries
 
@@ -94,9 +90,6 @@ macOS/Linux:
 }
 ```
 
-Absolute paths are required. If the `uv` binary is not in your `PATH`, specify
-the full path instead.
-
 ## Troubleshooting
 
 - **Port conflicts:** the server runs on port `8080` in SSE mode by default. If
@@ -107,8 +100,8 @@ the full path instead.
   the container starts.
 - **Missing credentials:** if the server exits with a "Missing Boomi
   credentials" error, set the `BOOMI_ACCOUNT`, `BOOMI_USER` and `BOOMI_SECRET`
-  environment variables. Cursor and Claude let you specify these in their
-  settings UI or you can provide a `.env` file in the working directory.
+  environment variables. Cursor and Claude Desktop let you specify these in their
+  settings UI, or you can provide a `.env` file in the root directory of your cloned `boomi-mcp-server` project.
 - **Configuration differences:** Cursor reads `mcp.json` while Claude Desktop
   uses `claude_desktop_config.json`. Both require absolute paths and support
   only the `command` and `args` fields.


### PR DESCRIPTION
- I updated README.md to clarify `uv lock` usage, the `${workspaceFolder}` variable, and ensured consistent use of 'Claude Desktop'.
- I updated docs/cursor_setup.md to clarify `${workspaceFolder}` replacement, the `.env` file location for credentials, and ensured consistent use of 'Claude Desktop'.
- I reviewed the example client script and CI/linting configurations; no major issues found.